### PR TITLE
Fix #2 : not mdsvr but markdownserver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ You don't need any special preparation to try to start server. Just execute belo
     $ virtualenv .venv
     $ source .venv/bin/activate
     (.venv)$ pip install -r requirements.txt
-    (.venv)$ mdsvr
+    (.venv)$ markdownserver
         Bottle v0.12.8 server starting up (using WSGIRefServer())...
         Listening on http://localhost:8009/
 


### PR DESCRIPTION
refs #2

`mdsvr` is available only when you have installed with `pip markdown-server`..