### PR TITLE
Create .gitattributes to override repository language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+markdownserver/resources/html/sample.md.html linguist-documentation
+markdownserver/resources/css/github.css linguist-vendored


### PR DESCRIPTION
It's better to let GitHub recognize this repository as python, not html.

https://github.com/github/linguist/blob/master/docs/overrides.md