### PR TITLE
rename convert to avoid imagemagick conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     entry_points={
         "console_scripts": [
             "markdownserver=markdownserver:main",
-            "convert=markdownserver.markdown_converter:main",
+            "markdownconvert=markdownserver.markdown_converter:main",
         ]
     },
 )


### PR DESCRIPTION
`convert` is a very popular imagemagick utility.  This renames the markdown one to `markdownconvert` to avoid the conflict.